### PR TITLE
Fix the backup and restore scripts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690716044,
-        "narHash": "sha256-5rhZK0YMQOK+FaOC72leFXUFuCBxKH5SRzUQqpePqQE=",
+        "lastModified": 1703383890,
+        "narHash": "sha256-3LNEli9ET6L+bdj7fxo4yLOKnfAYSGxUMBWt0Yx7oUQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b1b263e5f7f899704c6b592f2096bc8f719dc181",
+        "rev": "6586ea5fb647f22ff7f671003a888ffbc0950a7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This has required to eschew the `wrapProgram` script as they then go on to figure out their "installed" location via `dirname` which now points to the nixstore location. Thus leading to the backup being bogus and also not written. Fortunately all of the interesting programs are shell scripts, so we can just prepend some text to them.

Another issue was that we were deleting the `lst` file that OH was relying on to clean up the backup afterwards.